### PR TITLE
list projects for more > 50

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+venv*
 __pycache__/
 *.py[co]
 *.egg

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ python3 -m twine upload dist/mergin-client-x.y.z.tar.gz
 
 ### Installing deps
 
-Python 3.7+ required. Create `mergin/deps` folder where [geodiff](https://github.com/lutraconsulting/geodiff) lib is supposed to be and install dependencies:
+Python 3.7+ required. Create `mergin/deps` folder where [geodiff](https://github.com/MerginMaps/geodiff) lib is supposed to be and install dependencies:
 ```
     rm -r mergin/deps
     mkdir mergin/deps

--- a/mergin/cli.py
+++ b/mergin/cli.py
@@ -233,10 +233,10 @@ def create(ctx, project, public, from_dir):
 )
 @click.option(
     "--order_params",
-    help="optional attributes for sorting the list."
-         "It should be a comma separated attribute names"
-         "with _asc or _desc appended for sorting direction."
-         "For example: \"namespace_asc,disk_usage_desc\"."
+    help="optional attributes for sorting the list. "
+         "It should be a comma separated attribute names "
+         "with _asc or _desc appended for sorting direction. "
+         "For example: \"namespace_asc,disk_usage_desc\". "
          "Available attrs: namespace, name, created, updated, disk_usage, creator",
 )
 @click.pass_context

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -424,6 +424,57 @@ class MerginClient:
         projects = json.load(resp)
         return projects
 
+    def projects_list(self, tags=None, user=None, flag=None, name=None, namespace=None, order_params=None):
+        """
+        Find all available Mergin Maps projects. 
+        
+        Calls paginated_projects_list for all pages. Can take significant time to fetch all pages. 
+
+        :param tags: Filter projects by tags ('valid_qgis', 'mappin_use', input_use')
+        :type tags: List
+
+        :param user: Username for 'flag' filter. If not provided, it means user executing request.
+        :type user: String
+
+        :param flag: Predefined filter flag ('created', 'shared')
+        :type flag: String
+
+        :param name: Filter projects with name like name
+        :type name: String
+
+        :param namespace: Filter projects with namespace like namespace
+        :type namespace: String
+
+        :param order_params: optional attributes for sorting the list. It should be a comma separated attribute names
+            with _asc or _desc appended for sorting direction. For example: "namespace_asc,disk_usage_desc".
+            Available attrs: namespace, name, created, updated, disk_usage, creator
+        :type order_params: String
+
+        :rtype: List[Dict]
+        """
+        projects_list = []
+        page_i = 1
+        fetched_projects = 0
+        while True:
+            resp = mc.paginated_projects_list(
+                page=page_i,
+                per_page=50,
+                tags=tags, 
+                user=user, 
+                flag=flag, 
+                name=name,
+                namespace=namespace, 
+                order_params=order_params
+            )
+            fetched_projects += len(resp["projects"])
+            count = resp["count"]
+            projects_list += resp["projects"]
+            if fetched_projects < count:
+                page_i += 1
+            else:
+                break
+        return projects
+
     def project_info(self, project_path, since=None, version=None):
         """
         Fetch info about project.

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -424,38 +424,6 @@ class MerginClient:
         projects = json.load(resp)
         return projects
 
-    def projects_list(self, tags=None, user=None, flag=None, q=None):
-        """
-        Find all available Mergin Maps projects. It will always retrieve max 100 projects.
-        Consider using the paginated_projects_list instead.
-
-        :param tags: Filter projects by tags ('valid_qgis', 'mappin_use', input_use')
-        :type tags: List
-
-        :param user: Username for 'flag' filter. If not provided, it means user executing request.
-        :type user: String
-
-        :param flag: Predefined filter flag ('created', 'shared')
-        :type flag: String
-
-        :param q: Search query string
-        :type q: String
-
-        :rtype: List[Dict]
-        """
-        params = {}
-        if tags:
-            params["tags"] = ",".join(tags)
-        if user:
-            params["user"] = user
-        if flag:
-            params["flag"] = flag
-        if q:
-            params["q"] = q
-        resp = self.get("/v1/project", params)
-        projects = json.load(resp)
-        return projects
-
     def project_info(self, project_path, since=None, version=None):
         """
         Fetch info about project.

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -456,7 +456,7 @@ class MerginClient:
         page_i = 1
         fetched_projects = 0
         while True:
-            resp = mc.paginated_projects_list(
+            resp = self.paginated_projects_list(
                 page=page_i,
                 per_page=50,
                 tags=tags, 

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -452,7 +452,7 @@ class MerginClient:
 
         :rtype: List[Dict]
         """
-        projects_list = []
+        projects = []
         page_i = 1
         fetched_projects = 0
         while True:
@@ -468,7 +468,7 @@ class MerginClient:
             )
             fetched_projects += len(resp["projects"])
             count = resp["count"]
-            projects_list += resp["projects"]
+            projects += resp["projects"]
             if fetched_projects < count:
                 page_i += 1
             else:

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,10 @@ setup(
 
     platforms='any',
     install_requires=[
-        'python-dateutil==2.6.0',
-        'pygeodiff==1.0.5',
-        'pytz==2019.3',
-        'click',
+        'python-dateutil==2.8.2',
+        'pygeodiff==1.0.6',
+        'pytz==2022.1',
+        'click==8.1.3',
     ],
 
     entry_points={


### PR DESCRIPTION
fix #21

also added bunch of extra filters:

```
Usage: mergin list-projects [OPTIONS]

  List projects on the server.

Options:
  --flag TEXT          What kind of projects (e.g. 'created' for just my
                       projects,'shared' for projects shared with me. No flag
                       means returns all public projects.
  --name TEXT          Filter projects with name like name
  --namespace TEXT     Filter projects with namespace like namespace
  --order_params TEXT  optional attributes for sorting the list.It should be a
                       comma separated attribute nameswith _asc or _desc
                       appended for sorting direction.For example:
                       "namespace_asc,disk_usage_desc".Available attrs:
                       namespace, name, created, updated, disk_usage, creator
  --help               Show this message and exit.
```