### PR TITLE
add method for defining list of tables to ignore from geodiff operations

### DIFF
--- a/mergin/merginproject.py
+++ b/mergin/merginproject.py
@@ -731,3 +731,15 @@ class MerginProject:
         shutil.rmtree(self.unfinished_pull_dir)
         self.log.info("unfinished pull resolved successfuly!")
         return conflicts
+
+    def set_tables_to_skip(self, tables):
+        """
+        Set list of tables to exclude from geodiff operations. Once defined, these
+        tables will be excluded from the following operations: create changeset,
+        apply changeset, rebase, get database schema, dump database contents, copy
+        database between different drivers.
+
+        Tables passes as semicolon separated list, e.g. "table1;table2;...;tableN".
+        If empty string is passed, list will be reset.
+        """
+        self.geodiff.set_tables_to_skip(tables)

--- a/mergin/merginproject.py
+++ b/mergin/merginproject.py
@@ -739,7 +739,9 @@ class MerginProject:
         apply changeset, rebase, get database schema, dump database contents, copy
         database between different drivers.
 
-        Tables passes as semicolon separated list, e.g. "table1;table2;...;tableN".
-        If empty string is passed, list will be reset.
+        If empty list is passed, list will be reset.
+
+        :param tables: list of table names to ignore
+        :type tables: list[str]
         """
         self.geodiff.set_tables_to_skip(tables)


### PR DESCRIPTION
Add new method to `MerginProject` class to set list of tables which should be exculded from geodiff operations.


Requires geodiff with https://github.com/MerginMaps/geodiff/pull/182