### PR TITLE
Workspaces

### DIFF
--- a/mergin/client.py
+++ b/mergin/client.py
@@ -424,7 +424,16 @@ class MerginClient:
                 self.push_project(directory)
 
     def paginated_projects_list(
-        self, page=1, per_page=50, tags=None, user=None, flag=None, name=None, namespace=None, order_params=None
+        self,
+        page=1,
+        per_page=50,
+        tags=None,
+        user=None,
+        flag=None,
+        name=None,
+        only_namespace=None,
+        namespace=None,
+        order_params=None,
     ):
         """
         Find all available Mergin Maps projects.
@@ -440,6 +449,9 @@ class MerginClient:
 
         :param name: Filter projects with name like name
         :type name: String
+
+        :param only_namespace: Filter projects with namespace exactly equal to namespace
+        :type namespace: String
 
         :param namespace: Filter projects with namespace like namespace
         :type namespace: String
@@ -466,7 +478,9 @@ class MerginClient:
             params["flag"] = flag
         if name:
             params["name"] = name
-        if namespace:
+        if only_namespace:
+            params["only_namespace"] = only_namespace
+        elif namespace:
             params["namespace"] = namespace
         params["page"] = page
         params["per_page"] = per_page
@@ -476,7 +490,9 @@ class MerginClient:
         projects = json.load(resp)
         return projects
 
-    def projects_list(self, tags=None, user=None, flag=None, name=None, namespace=None, order_params=None):
+    def projects_list(
+        self, tags=None, user=None, flag=None, name=None, only_namespace=None, namespace=None, order_params=None
+    ):
         """
         Find all available Mergin Maps projects.
 
@@ -493,6 +509,9 @@ class MerginClient:
 
         :param name: Filter projects with name like name
         :type name: String
+
+        :param only_namespace: Filter projects with namespace exactly equal to namespace
+        :type namespace: String
 
         :param namespace: Filter projects with namespace like namespace
         :type namespace: String
@@ -515,6 +534,7 @@ class MerginClient:
                 user=user,
                 flag=flag,
                 name=name,
+                only_namespace=only_namespace,
                 namespace=namespace,
                 order_params=order_params,
             )

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -351,7 +351,7 @@ class MerginClient:
         return self._server_type
 
     def global_namespace(self):
-        """"
+        """
         Returns the name of the server's global namespace, if any.
         (Applies to CE server types)
 

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -767,9 +767,6 @@ class MerginClient:
         local_version = mp.metadata["version"]
         server_info = self.project_info(project_path, since=local_version)
 
-
-
-
         pull_changes = mp.get_pull_changes(server_info["files"])
 
         push_changes = mp.get_push_changes()

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -322,6 +322,16 @@ class MerginClient:
 
         return response
 
+    def workspaces_list(self):
+        """
+        Find all available workspaces
+
+        :rtype: List[Dict]
+        """
+        resp = self.get("/v1/workspaces")
+        workspaces = json.load(resp)
+        return workspaces
+
     def create_project(self, project_name, is_public=False, namespace=None):
         """
         Create new project repository in user namespace on Mergin Maps server.

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -635,7 +635,11 @@ class MerginClient:
         return True, free_space
 
     def user_info(self):
-        resp = self.get("/v1/user/" + self.username())
+        server_type = self.server_type()
+        if server_type == "old":
+            resp = self.get("/v1/user/" + self.username())
+        else:
+            resp = self.get("/v1/user/profile")
         return json.load(resp)
 
     def set_project_access(self, project_path, access):

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -345,6 +345,7 @@ class MerginClient:
                     self._server_type = "ee"
                 if "global_namespace" in config:
                     self._server_type = "ce"
+                    self._global_namespace = config["global_namespace"]
             except ClientError as e:
                 self._server_type = "old"
 
@@ -765,6 +766,10 @@ class MerginClient:
         project_path = mp.metadata["name"]
         local_version = mp.metadata["version"]
         server_info = self.project_info(project_path, since=local_version)
+
+
+
+
         pull_changes = mp.get_pull_changes(server_info["files"])
 
         push_changes = mp.get_push_changes()

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -346,7 +346,7 @@ class MerginClient:
                 config = json.load(resp)
                 if "user_workspaces_allowed" in config:
                     self._server_type = ServerType.EE
-                if "global_namespace" in config:
+                if "global_workspace" in config:
                     self._server_type = ServerType.CE
             except ClientError as e:
                 self._server_type = ServerType.OLD
@@ -619,7 +619,7 @@ class MerginClient:
 
     def user_info(self):
         server_type = self.server_type()
-        if server_type == "old":
+        if server_type == ServerType.OLD:
             resp = self.get("/v1/user/" + self.username())
         else:
             resp = self.get("/v1/user/profile")

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -351,25 +351,6 @@ class MerginClient:
 
         return self._server_type
 
-    def global_namespace(self):
-        """
-        Returns the name of the server's global namespace, if any.
-        (Applies to CE server types)
-
-        The value is cached for self's lifetime
-
-        :returns: server's global namespace name if exists, None otherwise
-        rtype: str
-        """
-        if not self._global_namespace:
-            try:
-                resp = self.get("/config")
-                config = json.load(resp)
-                self._global_namespace = config.get("global_namespace", None)
-            except ClientError as e:
-                self._global_namespace = None
-        return self._global_namespace
-
     def workspaces_list(self):
         """
         Find all available workspaces


### PR DESCRIPTION
`def global_namespace(self):` will be redundant with the upcoming API changes as this info should be available by `/workspaces` endpoint and CE and EE versions will be treated the same.