### PR TITLE
Fix autotests now with workspaces server

### DIFF
--- a/mergin/client.py
+++ b/mergin/client.py
@@ -402,7 +402,6 @@ class MerginClient:
             detail = f"Username: {self.username}, workspace name: {workspace_name}"
             raise ClientError(str(e), detail)
 
-
     def create_project(self, project_name, is_public=False, namespace=None):
         """
         Create new project repository in user namespace on Mergin Maps server.

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -399,7 +399,7 @@ class MerginClient:
         try:
             self.post("/v1/workspace", params, {"Content-Type": "application/json"})
         except Exception as e:
-            detail = f"Username: {self.username}, workspace name: {workspace_name}"
+            detail = f"Workspace name: {workspace_name}"
             raise ClientError(str(e), detail)
 
     def create_project(self, project_name, is_public=False, namespace=None):

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -384,6 +384,25 @@ class MerginClient:
         workspaces = json.load(resp)
         return workspaces
 
+    def create_workspace(self, workspace_name):
+        """
+        Create new workspace for currently active user.
+
+        :param workspace_name: Workspace name to create
+        :type workspace_name: String
+        """
+        if not self._user_info:
+            raise Exception("Authentication required")
+
+        params = {"name": workspace_name}
+
+        try:
+            self.post("/v1/workspace", params, {"Content-Type": "application/json"})
+        except Exception as e:
+            detail = f"Username: {self.username}, workspace name: {workspace_name}"
+            raise ClientError(str(e), detail)
+
+
     def create_project(self, project_name, is_public=False, namespace=None):
         """
         Create new project repository in user namespace on Mergin Maps server.

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -53,14 +53,10 @@ def create_client(user, pwd):
 
 
 def create_workspace_for_client(mc):
-    info = mc.user_info()
-
-    # check if mc already have workspace with its name
-    wsAlreadyCreated = len(list(filter(lambda x: x["name"] == mc.username(), info.get("workspaces")))) > 0
-    if wsAlreadyCreated:
+    try:
+        mc.create_workspace(mc.username())
+    except ClientError:
         return
-
-    mc.create_workspace(mc.username())
 
 
 def cleanup(mc, project, dirs):

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -36,14 +36,14 @@ CHANGED_SCHEMA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "
 @pytest.fixture(scope="function")
 def mc():
     client = create_client(API_USER, USER_PWD)
-    create_workspace_for_client( client )
+    create_workspace_for_client(client)
     return client
 
 
 @pytest.fixture(scope="function")
 def mc2():
     client = create_client(API_USER2, USER_PWD2)
-    create_workspace_for_client( client )
+    create_workspace_for_client(client)
     return client
 
 
@@ -56,11 +56,11 @@ def create_workspace_for_client(mc):
     info = mc.user_info()
 
     # check if mc already have workspace with its name
-    wsAlreadyCreated = len( list( filter( lambda x: x.name == mc.username, info.get("workspaces") ) ) ) > 0
+    wsAlreadyCreated = len(list(filter(lambda x: x.name == mc.username, info.get("workspaces")))) > 0
     if wsAlreadyCreated:
         return
 
-    mc.create_workspace( mc.username )
+    mc.create_workspace(mc.username)
 
 
 def cleanup(mc, project, dirs):

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -56,11 +56,11 @@ def create_workspace_for_client(mc):
     info = mc.user_info()
 
     # check if mc already have workspace with its name
-    wsAlreadyCreated = len(list(filter(lambda x: x.name == mc.username, info.get("workspaces")))) > 0
+    wsAlreadyCreated = len(list(filter(lambda x: x["name"] == mc.username(), info.get("workspaces")))) > 0
     if wsAlreadyCreated:
         return
 
-    mc.create_workspace(mc.username)
+    mc.create_workspace(mc.username())
 
 
 def cleanup(mc, project, dirs):

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -1780,13 +1780,7 @@ def test_project_versions_list(mc, mc2):
     # now user shold have write access
     assert mc.has_writing_permissions(test_project_fullname)
 
-    # test organization permissions
-    test_project_fullname = "testorg" + "/" + "test_org_permissions"
-
     # owner should have write access
-    assert mc.has_writing_permissions(test_project_fullname)
-
-    # writer should have write access
     assert mc2.has_writing_permissions(test_project_fullname)
 
 

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -35,17 +35,32 @@ CHANGED_SCHEMA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "
 
 @pytest.fixture(scope="function")
 def mc():
-    return create_client(API_USER, USER_PWD)
+    client = create_client(API_USER, USER_PWD)
+    create_workspace_for_client( client )
+    return client
 
 
 @pytest.fixture(scope="function")
 def mc2():
-    return create_client(API_USER2, USER_PWD2)
+    client = create_client(API_USER2, USER_PWD2)
+    create_workspace_for_client( client )
+    return client
 
 
 def create_client(user, pwd):
     assert SERVER_URL and SERVER_URL.rstrip("/") != "https://app.merginmaps.com" and user and pwd
     return MerginClient(SERVER_URL, login=user, password=pwd)
+
+
+def create_workspace_for_client(mc):
+    info = mc.user_info()
+
+    # check if mc already have workspace with its name
+    wsAlreadyCreated = len( list( filter( lambda x: x.name == mc.username, info.get("workspaces") ) ) ) > 0
+    if wsAlreadyCreated:
+        return
+
+    mc.create_workspace( mc.username )
 
 
 def cleanup(mc, project, dirs):

--- a/mergin/utils.py
+++ b/mergin/utils.py
@@ -33,6 +33,7 @@ def save_to_file(stream, path):
     :param path: destination file path
     """
     directory = os.path.abspath(os.path.dirname(path))
+
     os.makedirs(directory, exist_ok=True)
 
     with open(path, "wb") as output:


### PR DESCRIPTION
- Added `create_workspace` function to API so that test users can create their workspace (if does not have yet)
- Removed check for organisation project (used to be some predefined project in test.dev)

Note: tests that failed are those that usually fail in a feature branch - we need to address this, but let's not do it now.