### PR TITLE
Close logging file

### DIFF
--- a/mergin/client.py
+++ b/mergin/client.py
@@ -151,6 +151,17 @@ class MerginClient:
                 null_logger = logging.NullHandler()
                 self.log.addHandler(null_logger)
 
+    def close_log_file(self) -> None:
+        """Close log file if the logging to file is specified."""
+        for handler in self.log.handlers:
+            if isinstance(handler, logging.FileHandler):
+                self.log.removeHandler(handler)
+                handler.close()
+        # if not handler exist, create a null handler
+        if not self.log.handlers:
+            null_logger = logging.NullHandler()
+            self.log.addHandler(null_logger)
+
     @staticmethod
     def default_url():
         """Returns URL of the public instance of Mergin Maps"""

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta, date
 import pytest
 import pytz
 import sqlite3
+import importlib
 
 from .. import InvalidProject
 from ..client import MerginClient, ClientError, MerginProject, LoginError, decode_token_data, TokenError, ServerType
@@ -1893,6 +1894,9 @@ def test_version_info(mc):
 
 
 def test_logging_file():
+
+    importlib.reload(logging)
+
     # with ENV variable the FileHandle is created
     os.environ["MERGIN_CLIENT_LOG"] = "true"
     client = create_client(API_USER, USER_PWD)

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -1890,3 +1890,20 @@ def test_version_info(mc):
     created = datetime.strptime(info["created"], "%Y-%m-%dT%H:%M:%SZ")
     assert created.date() == date.today()
     assert info["changes"]["updated"][0]["size"] == 98304
+
+
+def test_logging_file():
+    # with ENV variable the FileHandle is created
+    os.environ["MERGIN_CLIENT_LOG"] = "true"
+    client = create_client(API_USER, USER_PWD)
+    del os.environ["MERGIN_CLIENT_LOG"]
+
+    # logger if FileHandler
+    assert len(client.log.handlers) == 1
+    assert isinstance(client.log.handlers[0], logging.FileHandler)
+
+    client.close_log_file()
+
+    # after closing log file the logger is NullHandler
+    assert len(client.log.handlers) == 1
+    assert isinstance(client.log.handlers[0], logging.NullHandler)


### PR DESCRIPTION
Adds simple function that properly close and remove FileHandler logger. Should be useful on windows and for use with DB Sync.