### PR TITLE
Improve how HTTP errors are reported as client errors

### DIFF
--- a/mergin/client.py
+++ b/mergin/client.py
@@ -202,8 +202,17 @@ class MerginClient:
         except urllib.error.HTTPError as e:
             if e.headers.get("Content-Type", "") == "application/problem+json":
                 info = json.load(e)
-                raise ClientError(info.get("detail"))
-            raise ClientError(e.read().decode("utf-8"))
+                err_detail = info.get("detail")
+            else:
+                err_detail = e.read().decode("utf-8")
+
+            error_msg = (
+                f"HTTP Error: {e.code} {e.reason}\n"
+                f"URL: {request.get_full_url()}\n"
+                f"Method: {request.get_method()}\n"
+                f"Detail: {err_detail}"
+            )
+            raise ClientError(error_msg)
         except urllib.error.URLError as e:
             # e.g. when DNS resolution fails (no internet connection?)
             raise ClientError("Error requesting " + request.full_url + ": " + str(e))

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -619,7 +619,7 @@ def test_available_storage_validation(mc):
         mc.push_project(project_dir)
     except ClientError as e:
         # Expecting "You have reached a data limit" 400 server error msg.
-        assert str(e) == "You have reached a data limit"
+        assert "You have reached a data limit" in str(e)
         got_right_err = True
     assert got_right_err
 


### PR DESCRIPTION
Previously we would only get the detail (e.g. `The requested URL was not found on the server.`) but there would be no information on what URL was actually accessed. This PR adds more info: URL, method and http error code (+reason)