### PR TITLE
Add hint for setting MERGIN_AUTH variable in Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,12 @@ is not permanent - it will expire after several hours.
 $ mergin --username john login
 Password: topsecret
 Login successful!
-To set the MERGIN_AUTH variable run:
+To set the MERGIN_AUTH variable run in Linux:
 export MERGIN_AUTH="Bearer ......."
+In Windows:
+SET MERGIN_AUTH=Bearer .......
 ```
+When setting the variable in Windows you do not quote the value.
 
 When the MERGIN_AUTH env variable is set (or passed with `--auth-token` command line argument),
 it is possible to run other commands without specifying username/password.

--- a/mergin/cli.py
+++ b/mergin/cli.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 import click
 import json
 import os
+import platform
 import sys
 import time
 import traceback
@@ -177,7 +178,11 @@ def login(ctx):
     if mc is not None:
         click.secho("Login successful!", fg="green")
         token = mc._auth_session["token"]
-        click.secho(f'To set the MERGIN_AUTH variable run:\nexport MERGIN_AUTH="{token}"')
+        if platform.system() == "Windows":
+            hint = f'To set the MERGIN_AUTH variable run:\nset MERGIN_AUTH={token}'
+        else:
+            hint = f'To set the MERGIN_AUTH variable run:\nexport MERGIN_AUTH="{token}"'
+        click.secho(hint)
 
 
 @cli.command()


### PR DESCRIPTION
Currently the hint for setting the variable works in Linux and confuses Windows users.
Suggested solution is to suggest a valid system-dependent hint.