### PR TITLE
Remove diff files

### DIFF
--- a/mergin/client.py
+++ b/mergin/client.py
@@ -14,7 +14,6 @@ import dateutil.parser
 import ssl
 from enum import Enum, auto
 import re
-from pathlib import Path
 
 from .common import ClientError, LoginError, InvalidProject
 from .merginproject import MerginProject

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -759,7 +759,6 @@ class MerginClient:
             return  # there is nothing to push (or we only deleted some files)
         push_project_wait(job)
         push_project_finalize(job)
-        self.clean_temp_files(directory)
 
     def pull_project(self, directory):
         """
@@ -992,15 +991,3 @@ class MerginClient:
         """
         info = self.project_info(project_path)
         return info["permissions"]["upload"]
-
-    def clean_temp_files(self, directory: str) -> None:
-        """
-        Removes all files matchning patter "*-diff-*" from .mergin folder inside specified folder.
-
-        :param directory: project's local path
-        :type directory: str
-        """
-        mergin_dir = Path(directory) / ".mergin"
-        if mergin_dir.exists():
-            for file in mergin_dir.glob("*-diff-*"):
-                file.unlink()

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -14,6 +14,7 @@ import dateutil.parser
 import ssl
 from enum import Enum, auto
 import re
+from pathlib import Path
 
 from .common import ClientError, LoginError, InvalidProject
 from .merginproject import MerginProject
@@ -758,6 +759,7 @@ class MerginClient:
             return  # there is nothing to push (or we only deleted some files)
         push_project_wait(job)
         push_project_finalize(job)
+        self.clean_temp_files(directory)
 
     def pull_project(self, directory):
         """
@@ -990,3 +992,15 @@ class MerginClient:
         """
         info = self.project_info(project_path)
         return info["permissions"]["upload"]
+
+    def clean_temp_files(self, directory: str) -> None:
+        """
+        Removes all files matchning patter "*-diff-*" from .mergin folder inside specified folder.
+
+        :param directory: project's local path
+        :type directory: str
+        """
+        mergin_dir = Path(directory) / ".mergin"
+        if mergin_dir.exists():
+            for file in mergin_dir.glob("*-diff-*"):
+                file.unlink()

--- a/mergin/client_push.py
+++ b/mergin/client_push.py
@@ -286,6 +286,8 @@ def push_project_finalize(job):
 
     job.tmp_dir.cleanup()  # delete our temporary dir and all its content
 
+    remove_diff_files(job)
+
     job.mp.log.info("--- push finished - new project version " + job.server_resp["version"])
 
 

--- a/mergin/client_push.py
+++ b/mergin/client_push.py
@@ -316,3 +316,13 @@ def _do_upload(item, job):
 
     item.upload_blocking(job.mc, job.mp)
     job.transferred_size += item.size
+
+
+def remove_diff_files(job) -> None:
+    """Looks for diff files in the job and removes them."""
+
+    for change in job.changes["updated"]:
+        if "diff" in change.keys():
+            diff_file = job.mp.fpath_meta(change["diff"]["path"])
+            if os.path.exists(diff_file):
+                os.remove(diff_file)

--- a/mergin/client_push.py
+++ b/mergin/client_push.py
@@ -14,6 +14,7 @@ import hashlib
 import pprint
 import tempfile
 import concurrent.futures
+import os
 
 from .common import UPLOAD_CHUNK_SIZE, ClientError
 from .merginproject import MerginProject

--- a/mergin/merginproject.py
+++ b/mergin/merginproject.py
@@ -347,15 +347,19 @@ class MerginProject:
                 self.geodiff.create_changeset(origin_file, current_file, diff_file)
                 if self.geodiff.has_changes(diff_file):
                     diff_size = os.path.getsize(diff_file)
-                    file["checksum"] = file["origin_checksum"]  # need to match basefile on server
-                    file["chunks"] = [str(uuid.uuid4()) for i in range(math.ceil(diff_size / UPLOAD_CHUNK_SIZE))]
-                    file["mtime"] = datetime.fromtimestamp(os.path.getmtime(current_file), tzlocal())
-                    file["diff"] = {
-                        "path": diff_name,
-                        "checksum": generate_checksum(diff_file),
-                        "size": diff_size,
-                        "mtime": datetime.fromtimestamp(os.path.getmtime(diff_file), tzlocal()),
-                    }
+                    if diff_size > 0:
+                        file["checksum"] = file["origin_checksum"]  # need to match basefile on server
+                        file["chunks"] = [str(uuid.uuid4()) for i in range(math.ceil(diff_size / UPLOAD_CHUNK_SIZE))]
+                        file["mtime"] = datetime.fromtimestamp(os.path.getmtime(current_file), tzlocal())
+                        file["diff"] = {
+                            "path": diff_name,
+                            "checksum": generate_checksum(diff_file),
+                            "size": diff_size,
+                            "mtime": datetime.fromtimestamp(os.path.getmtime(diff_file), tzlocal()),
+                        }
+                    else:
+                        os.remove(diff_file)
+                        not_updated.append(file)
                 else:
                     not_updated.append(file)
             except (pygeodiff.GeoDiffLibError, pygeodiff.GeoDiffLibConflictError) as e:

--- a/mergin/merginproject.py
+++ b/mergin/merginproject.py
@@ -347,20 +347,18 @@ class MerginProject:
                 self.geodiff.create_changeset(origin_file, current_file, diff_file)
                 if self.geodiff.has_changes(diff_file):
                     diff_size = os.path.getsize(diff_file)
-                    if diff_size > 0:
-                        file["checksum"] = file["origin_checksum"]  # need to match basefile on server
-                        file["chunks"] = [str(uuid.uuid4()) for i in range(math.ceil(diff_size / UPLOAD_CHUNK_SIZE))]
-                        file["mtime"] = datetime.fromtimestamp(os.path.getmtime(current_file), tzlocal())
-                        file["diff"] = {
-                            "path": diff_name,
-                            "checksum": generate_checksum(diff_file),
-                            "size": diff_size,
-                            "mtime": datetime.fromtimestamp(os.path.getmtime(diff_file), tzlocal()),
-                        }
-                    else:
-                        os.remove(diff_file)
-                        not_updated.append(file)
+                    file["checksum"] = file["origin_checksum"]  # need to match basefile on server
+                    file["chunks"] = [str(uuid.uuid4()) for i in range(math.ceil(diff_size / UPLOAD_CHUNK_SIZE))]
+                    file["mtime"] = datetime.fromtimestamp(os.path.getmtime(current_file), tzlocal())
+                    file["diff"] = {
+                        "path": diff_name,
+                        "checksum": generate_checksum(diff_file),
+                        "size": diff_size,
+                        "mtime": datetime.fromtimestamp(os.path.getmtime(diff_file), tzlocal()),
+                    }
                 else:
+                    if os.path.exists(diff_file):
+                        os.remove(diff_file)
                     not_updated.append(file)
             except (pygeodiff.GeoDiffLibError, pygeodiff.GeoDiffLibConflictError) as e:
                 self.log.warning("failed to create changeset for " + path)


### PR DESCRIPTION
In `MerginProject` method `get_push_changes()` check for zero size diff files and removes them.

In `MerginClient`  method `push_project()` clean any existing diff files when the method ends. 

Fixes #47 