### PR TITLE
Add immediate project removal to fix auto-tests

### DIFF
--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -1039,6 +1039,8 @@ def _use_wal(db_file):
     con = sqlite3.connect(db_file)
     cursor = con.cursor()
     cursor.execute("PRAGMA journal_mode=wal;")
+    cursor.close()
+    con.close()
 
 
 def _create_test_table(db_file):

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -63,7 +63,7 @@ def create_workspace_for_client(mc):
 def cleanup(mc, project, dirs):
     # cleanup leftovers from previous test if needed such as remote project and local directories
     try:
-        mc.delete_project(project)
+        mc.delete_project_now(project)
     except ClientError:
         pass
     remove_folders(dirs)
@@ -105,17 +105,17 @@ def test_create_delete_project(mc):
     assert any(p for p in projects if p["name"] == test_project and p["namespace"] == API_USER)
 
     # try again
-    with pytest.raises(ClientError, match=f"Project {test_project} already exists"):
+    with pytest.raises(ClientError, match=f"already exists"):
         mc.create_project(test_project)
 
     # remove project
-    mc.delete_project(API_USER + "/" + test_project)
+    mc.delete_project_now(API_USER + "/" + test_project)
     projects = mc.projects_list(flag="created")
     assert not any(p for p in projects if p["name"] == test_project and p["namespace"] == API_USER)
 
     # try again, nothing to delete
     with pytest.raises(ClientError):
-        mc.delete_project(API_USER + "/" + test_project)
+        mc.delete_project_now(API_USER + "/" + test_project)
 
 
 def test_create_remote_project_from_local(mc):

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -1076,18 +1076,18 @@ def _delete_spatial_table(db_file):
 
 def _check_test_table(db_file):
     """Checks whether the 'test' table exists and has one row - otherwise fails with an exception."""
-    # con_verify = sqlite3.connect(db_file)
-    # cursor_verify = con_verify.cursor()
-    # cursor_verify.execute('select count(*) from test;')
-    # assert cursor_verify.fetchone()[0] == 1
     assert _get_table_row_count(db_file, "test") == 1
 
 
 def _get_table_row_count(db_file, table):
-    con_verify = sqlite3.connect(db_file)
-    cursor_verify = con_verify.cursor()
-    cursor_verify.execute("select count(*) from {};".format(table))
-    return cursor_verify.fetchone()[0]
+    try:
+        con_verify = sqlite3.connect(db_file)
+        cursor_verify = con_verify.cursor()
+        cursor_verify.execute("select count(*) from {};".format(table))
+        return cursor_verify.fetchone()[0]
+    finally:
+        cursor_verify.close()
+        con_verify.close()
 
 
 def _is_file_updated(filename, changes_dict):

--- a/mergin/utils.py
+++ b/mergin/utils.py
@@ -232,3 +232,26 @@ def edit_conflict_file_name(path, user, version):
     ext = "".join(Path(tail).suffixes)
     file_name = tail.replace(ext, "")
     return os.path.join(head, file_name) + f" (edit conflict, {user} v{version}).json"
+
+
+def is_version_acceptable(version, min_version):
+    """
+    Checks whether given version is at least min_version or later (both given as strings).
+
+    Versions are expected to be using syntax X.Y.Z
+
+    Returns true if version >= min_version
+    """
+    m = re.search("(\\d+)[.](\\d+)", min_version)
+    min_major, min_minor = m.group(1), m.group(2)
+
+    if len(version) == 0:
+        return False   # unknown version is assumed to be old
+
+    m = re.search("(\\d+)[.](\\d+)", version)
+    if m is None:
+        return False
+
+    major, minor = m.group(1), m.group(2)
+
+    return major > min_major or (major == min_major and minor >= min_minor)

--- a/mergin/utils.py
+++ b/mergin/utils.py
@@ -246,7 +246,7 @@ def is_version_acceptable(version, min_version):
     min_major, min_minor = m.group(1), m.group(2)
 
     if len(version) == 0:
-        return False   # unknown version is assumed to be old
+        return False  # unknown version is assumed to be old
 
     m = re.search("(\\d+)[.](\\d+)", version)
     if m is None:


### PR DESCRIPTION
Newer server versions started to use scheduled delete, which broke the tests, because it was not possible to re-create the same projects earlier than in a couple of days.