### PR TITLE
Use explicit function calls to get project metadata

### DIFF
--- a/mergin/cli.py
+++ b/mergin/cli.py
@@ -495,7 +495,7 @@ def show_version(ctx, version):
         return
     directory = os.getcwd()
     mp = MerginProject(directory)
-    project_path = mp.metadata["name"]
+    project_path = mp.project_full_name()
     # TODO: handle exception when version not found
     version_info_dict = mc.project_version_info(project_path, version)[0]
     click.secho("Project: " + version_info_dict["namespace"] + "/" + version_info_dict["project_name"])
@@ -514,7 +514,7 @@ def show_file_history(ctx, path):
         return
     directory = os.getcwd()
     mp = MerginProject(directory)
-    project_path = mp.metadata["name"]
+    project_path = mp.project_full_name()
     info_dict = mc.project_file_history_info(project_path, path)
     # TODO: handle exception if history not found
     history_dict = info_dict["history"]
@@ -538,7 +538,7 @@ def show_file_changeset(ctx, path, version):
         return
     directory = os.getcwd()
     mp = MerginProject(directory)
-    project_path = mp.metadata["name"]
+    project_path = mp.project_full_name()
     info_dict = mc.project_file_changeset_info(project_path, path, version)
     # TODO: handle exception if Diff not found
     click.secho(json.dumps(info_dict, indent=2))

--- a/mergin/client_push.py
+++ b/mergin/client_push.py
@@ -84,8 +84,8 @@ def push_project_async(mc, directory):
     if mp.has_unfinished_pull():
         raise ClientError("Project is in unfinished pull state. Please resolve unfinished pull and try again.")
 
-    project_path = mp.metadata["name"]
-    local_version = mp.metadata["version"]
+    project_path = mp.project_full_name()
+    local_version = mp.version()
 
     mp.log.info("--- version: " + mc.user_agent_info())
     mp.log.info(f"--- start push {project_path}")
@@ -272,12 +272,14 @@ def push_project_finalize(job):
                 job.mp.log.info("cancel response: " + str(err2))
             raise err
 
-    job.mp.metadata = {
-        "name": job.project_path,
-        "version": job.server_resp["version"],
-        "project_id": job.server_resp["id"],
-        "files": job.server_resp["files"],
-    }
+    job.mp.update_metadata(
+        {
+            "name": job.project_path,
+            "version": job.server_resp["version"],
+            "project_id": job.server_resp["id"],
+            "files": job.server_resp["files"],
+        }
+    )
     try:
         job.mp.apply_push_changes(job.changes)
     except Exception as e:

--- a/mergin/merginproject.py
+++ b/mergin/merginproject.py
@@ -136,79 +136,80 @@ class MerginProject:
         return self.fpath(file, self.cache_dir)
 
     def project_full_name(self) -> str:
-        """ Returns fully qualified project name: <workspace>/<name> """
+        """Returns fully qualified project name: <workspace>/<name>"""
         if self._metadata is None:
             self._read_metadata()
         return self._metadata["name"]
 
     def project_name(self) -> str:
-        """ Returns only project name, without its workspace name """
+        """Returns only project name, without its workspace name"""
         full_name = self.project_full_name()
         slash_index = full_name.index("/")
-        return full_name[slash_index+1:]
+        return full_name[slash_index + 1 :]
 
     def workspace_name(self) -> str:
-        """ Returns name of the workspace where the project belongs """
+        """Returns name of the workspace where the project belongs"""
         full_name = self.project_full_name()
         slash_index = full_name.index("/")
         return full_name[:slash_index]
 
     def project_id(self) -> str:
-        """ Returns ID of the project (UUID using 8-4-4-4-12 formatting without braces) """
+        """Returns ID of the project (UUID using 8-4-4-4-12 formatting without braces)"""
         if self._metadata is None:
             self._read_metadata()
         return self._metadata["project_id"]
 
     def workspace_id(self) -> int:
-        """ Returns ID of the workspace where the project belongs """
+        """Returns ID of the workspace where the project belongs"""
         # unfortunately we currently do not have information about workspace ID
         # in project's metadata...
         raise NotImplementedError
 
     def version(self) -> str:
-        """ Returns project version (e.g. "v123") """
+        """Returns project version (e.g. "v123")"""
         if self._metadata is None:
             self._read_metadata()
         return self._metadata["version"]
 
     def files(self) -> list:
-        """ Returns project's list of files (each file being a dictionary) """
+        """Returns project's list of files (each file being a dictionary)"""
         if self._metadata is None:
             self._read_metadata()
         return self._metadata["files"]
 
     @property
     def metadata(self) -> dict:
-        """ Gets raw access to metadata. Kept only for backwards compatibility and will be removed. """
+        """Gets raw access to metadata. Kept only for backwards compatibility and will be removed."""
         # as we will change what is written in mergin.json, we do not want
         # client code to use this getter, and rather use project_full_name(), version() etc.
         from warnings import warn
+
         warn("MerginProject.metadata getter should not be used anymore", DeprecationWarning)
         if self._metadata is None:
             self._read_metadata()
         return self._metadata
 
     def _read_metadata(self):
-        """ Loads the project's metadata from JSON """
+        """Loads the project's metadata from JSON"""
         if not os.path.exists(self.fpath_meta("mergin.json")):
             raise InvalidProject("Project metadata has not been created yet")
         with open(self.fpath_meta("mergin.json"), "r") as file:
             self._metadata = json.load(file)
 
     def update_metadata(self, data: dict):
-        """ Writes project metadata and updates cached metadata. """
+        """Writes project metadata and updates cached metadata."""
         self._metadata = data
         MerginProject.write_metadata(self.dir, data)
 
     @staticmethod
     def write_metadata(project_directory: str, data: dict):
-        """ Writes project metadata to <project_directory>/.mergin/mergin.json
+        """Writes project metadata to <project_directory>/.mergin/mergin.json
 
         In most cases it is better to call update_metadata() as that will also
         update in-memory cache of metadata in MerginProject - this static method is
         useful for cases when this is the first time metadata are being written
         (and therefore creating MerginProject would fail).
-         """
+        """
         meta_dir = os.path.join(project_directory, ".mergin")
         os.makedirs(meta_dir, exist_ok=True)
         metadata_json_file = os.path.abspath(os.path.join(meta_dir, "mergin.json"))

--- a/mergin/report.py
+++ b/mergin/report.py
@@ -214,7 +214,7 @@ def create_report(mc, directory, since, to, out_file):
           List of warnings/issues for versions which could not be processed (e.g. broken history with missing diff)
     """
     mp = MerginProject(directory)
-    project = mp.metadata["name"]
+    project = mp.project_full_name()
     mp.log.info(f"--- Creating changesets report for {project} from {since} to {to if to else 'latest'} versions ----")
     versions = mc.project_versions(project, since, to if to else None)
     versions_map = {v["name"]: v for v in versions}


### PR DESCRIPTION
This is to make the code more clear about what data it gets from metadata, and also to be ready for future when we change the way how metadata are stored.