### PR TITLE
allow querying project information by project ID (fix #179)

### DIFF
--- a/mergin/client.py
+++ b/mergin/client.py
@@ -623,7 +623,7 @@ class MerginClient:
                 break
         return projects
 
-    def project_info(self, project_path, since=None, version=None):
+    def project_info(self, project_path_or_id, since=None, version=None):
         """
         Fetch info about project.
 
@@ -639,7 +639,11 @@ class MerginClient:
         # since and version are mutually exclusive
         if version:
             params = {"version": version}
-        resp = self.get("/v1/project/{}".format(project_path), params)
+
+        if re.match("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", project_path_or_id):
+            resp = self.get("/v1/project/by_uuid/{}".format(project_path_or_id), params)
+        else:
+            resp = self.get("/v1/project/{}".format(project_path_or_id), params)
         return json.load(resp)
 
     def project_versions(self, project_path, since=None, to=None):

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -627,8 +627,8 @@ class MerginClient:
         """
         Fetch info about project.
 
-        :param project_path: Project's full name (<namespace>/<name>)
-        :type project_path: String
+        :param project_path_or_id: Project's full name (<namespace>/<name>) or id
+        :type project_path_or_id: String
         :param since: Version to track history of geodiff files from
         :type since: String
         :param version: Project version to get details for (particularly list of files)

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -150,6 +150,13 @@ def test_create_remote_project_from_local(mc):
     assert project_info["namespace"] == API_USER
     assert project_info["id"] == source_mp.project_id()
 
+    # check project metadata retrieval by id
+    project_info = mc.project_info(source_mp.project_id())
+    assert project_info["version"] == "v1"
+    assert project_info["name"] == test_project
+    assert project_info["namespace"] == API_USER
+    assert project_info["id"] == source_mp.project_id()
+
     versions = mc.project_versions(project)
     assert len(versions) == 1
     assert versions[0]["name"] == "v1"


### PR DESCRIPTION
Make `project_info()` function accept either project ID or full project name to get project info.

Fixes #179.