### PR TITLE
copy log file to the temp dir before removing project directory

### DIFF
--- a/mergin/client_pull.py
+++ b/mergin/client_pull.py
@@ -16,7 +16,6 @@ import pprint
 import shutil
 import tempfile
 import typing
-from pathlib import Path
 
 import concurrent.futures
 
@@ -56,6 +55,7 @@ class DownloadJob:
         self.mp = mp  # MerginProject instance
         self.is_cancelled = False
         self.project_info = project_info  # parsed JSON with project info returned from the server
+        self.failure_log_file = None # log file, copied from the project directory if download fails
 
     def dump(self):
         print("--- JOB ---", self.total_size, "bytes")
@@ -100,6 +100,8 @@ def _cleanup_failed_download(directory, mergin_project=None):
     If a download job fails, there will be the newly created directory left behind with some
     temporary files in it. We want to remove it because a new download would fail because
     the directory already exists.
+
+    Returns path to the client log file or None if log file does not exist.
     """
     # First try to get the Mergin Maps project logger and remove its handlers to allow the log file deletion
     if mergin_project is not None:
@@ -107,23 +109,16 @@ def _cleanup_failed_download(directory, mergin_project=None):
 
     # keep log file as it might contain useful debug info
     log_file = os.path.join(directory, ".mergin", "client-log.txt")
-    dest_file = None
+    dest_path = None
 
     if os.path.exists(log_file):
-        dest_file = os.path.join(tempfile.gettempdir(), os.path.split(log_file)[1])
-        head, tail = os.path.split(os.path.normpath(dest_file))
-        ext = "".join(Path(tail).suffixes)
-        file_name = tail.replace(ext, "")
-
-        i = 0
-        while os.path.exists(dest_file):
-            i += 1
-            dest_file = os.path.join(head, file_name) + f"_{i}{ext}"
-
-        shutil.copyfile(log_file, dest_file)
+        tmp_file = tempfile.NamedTemporaryFile(prefix="mergin-", suffix=".txt", delete=False)
+        tmp_file.close()
+        dest_path = tmp_file.name
+        shutil.copyfile(log_file, dest_path)
 
     shutil.rmtree(directory)
-    return dest_file
+    return dest_path
 
 
 def download_project_async(mc, project_path, directory, project_version=None):
@@ -151,8 +146,7 @@ def download_project_async(mc, project_path, directory, project_version=None):
             project_info = latest_proj_info
 
     except ClientError as e:
-        file_path = _cleanup_failed_download(directory, mp)
-        e.log_file = file_path
+        _cleanup_failed_download(directory, mp)
         raise e
 
     version = project_info["version"] if project_info["version"] else "v0"
@@ -204,10 +198,8 @@ def download_project_is_running(job):
     """
     for future in job.futures:
         if future.done() and future.exception() is not None:
-            file_path = _cleanup_failed_download(job.directory, job.mp)
-            e = future.exception()
-            e.log_file = file_path
-            raise e
+            job.failure_log_file = _cleanup_failed_download(job.directory, job.mp)
+            raise future.exception()
         if future.running():
             return True
     return False
@@ -228,10 +220,8 @@ def download_project_finalize(job):
     # make sure any exceptions from threads are not lost
     for future in job.futures:
         if future.exception() is not None:
-            file_path = _cleanup_failed_download(job.directory, job.mp)
-            e = future.exception()
-            e.log_file = file_path
-            raise e
+            job.failure_log_file = _cleanup_failed_download(job.directory, job.mp)
+            raise future.exception()
 
     job.mp.log.info("--- download finished")
 

--- a/mergin/client_pull.py
+++ b/mergin/client_pull.py
@@ -146,6 +146,8 @@ def download_project_async(mc, project_path, directory, project_version=None):
             project_info = latest_proj_info
 
     except ClientError as e:
+        mp.log.error("Error while querying info: " + str(e))
+        mp.log.info("--- download aborted")
         _cleanup_failed_download(directory, mp)
         raise e
 
@@ -198,6 +200,8 @@ def download_project_is_running(job):
     """
     for future in job.futures:
         if future.done() and future.exception() is not None:
+            job.mp.log.error("Error while downloading project: " + str(future.exception()))
+            job.mp.log.info("--- download aborted")
             job.failure_log_file = _cleanup_failed_download(job.directory, job.mp)
             raise future.exception()
         if future.running():
@@ -220,6 +224,8 @@ def download_project_finalize(job):
     # make sure any exceptions from threads are not lost
     for future in job.futures:
         if future.exception() is not None:
+            job.mp.log.error("Error while downloading project: " + str(future.exception()))
+            job.mp.log.info("--- download aborted")
             job.failure_log_file = _cleanup_failed_download(job.directory, job.mp)
             raise future.exception()
 
@@ -645,6 +651,8 @@ def download_file_finalize(job):
     """
     download_files_finalize(job)
 
+            job.mp.log.error("Error while downloading file: " + str(future.exception()))
+            job.mp.log.info("--- download aborted")
 
 def download_diffs_async(mc, project_directory, file_path, versions):
     """

--- a/mergin/client_pull.py
+++ b/mergin/client_pull.py
@@ -146,11 +146,9 @@ def download_project_async(mc, project_path, directory, project_version=None):
         else:
             project_info = latest_proj_info
 
-    except ClientError as e:
-        mp.log.error("Error while querying info: " + str(e))
-        mp.log.info("--- download aborted")
+    except ClientError:
         _cleanup_failed_download(directory, mp)
-        raise e
+        raise
 
     version = project_info["version"] if project_info["version"] else "v0"
 
@@ -656,8 +654,6 @@ def download_file_finalize(job):
     """
     download_files_finalize(job)
 
-            job.mp.log.error("Error while downloading file: " + str(future.exception()))
-            job.mp.log.info("--- download aborted")
 
 def download_diffs_async(mc, project_directory, file_path, versions):
     """

--- a/mergin/client_pull.py
+++ b/mergin/client_pull.py
@@ -55,7 +55,7 @@ class DownloadJob:
         self.mp = mp  # MerginProject instance
         self.is_cancelled = False
         self.project_info = project_info  # parsed JSON with project info returned from the server
-        self.failure_log_file = None # log file, copied from the project directory if download fails
+        self.failure_log_file = None  # log file, copied from the project directory if download fails
 
     def dump(self):
         print("--- JOB ---", self.total_size, "bytes")

--- a/mergin/client_pull.py
+++ b/mergin/client_pull.py
@@ -16,6 +16,7 @@ import pprint
 import shutil
 import tempfile
 import typing
+import traceback
 
 import concurrent.futures
 
@@ -200,7 +201,7 @@ def download_project_is_running(job):
     """
     for future in job.futures:
         if future.done() and future.exception() is not None:
-            job.mp.log.error("Error while downloading project: " + str(future.exception()))
+            job.mp.log.error("Error while downloading project: " + "".join(traceback.format_exception(future.exception())))
             job.mp.log.info("--- download aborted")
             job.failure_log_file = _cleanup_failed_download(job.directory, job.mp)
             raise future.exception()
@@ -224,7 +225,7 @@ def download_project_finalize(job):
     # make sure any exceptions from threads are not lost
     for future in job.futures:
         if future.exception() is not None:
-            job.mp.log.error("Error while downloading project: " + str(future.exception()))
+            job.mp.log.error("Error while downloading project: " + "".join(traceback.format_exception(future.exception())))
             job.mp.log.info("--- download aborted")
             job.failure_log_file = _cleanup_failed_download(job.directory, job.mp)
             raise future.exception()

--- a/mergin/client_pull.py
+++ b/mergin/client_pull.py
@@ -201,7 +201,9 @@ def download_project_is_running(job):
     """
     for future in job.futures:
         if future.done() and future.exception() is not None:
-            job.mp.log.error("Error while downloading project: " + "".join(traceback.format_exception(future.exception())))
+            job.mp.log.error(
+                "Error while downloading project: " + "".join(traceback.format_exception(future.exception()))
+            )
             job.mp.log.info("--- download aborted")
             job.failure_log_file = _cleanup_failed_download(job.directory, job.mp)
             raise future.exception()
@@ -225,7 +227,9 @@ def download_project_finalize(job):
     # make sure any exceptions from threads are not lost
     for future in job.futures:
         if future.exception() is not None:
-            job.mp.log.error("Error while downloading project: " + "".join(traceback.format_exception(future.exception())))
+            job.mp.log.error(
+                "Error while downloading project: " + "".join(traceback.format_exception(future.exception()))
+            )
             job.mp.log.info("--- download aborted")
             job.failure_log_file = _cleanup_failed_download(job.directory, job.mp)
             raise future.exception()

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -2216,6 +2216,7 @@ def test_download_files(mc: MerginClient):
     with pytest.raises(ClientError, match=f"No \\[non_existing\\.file\\] exists at version v3"):
         mc.download_files(project_dir, [f_updated, "non_existing.file"], version="v3")
 
+
 def test_download_failure(mc):
     test_project = "test_download_failure"
     project = API_USER + "/" + test_project

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -2253,20 +2253,11 @@ def test_download_failure(mc):
     remove_folders([download_dir])
     job = download_project_async(mc, project, download_dir)
     os.makedirs(os.path.join(download_dir, "base.gpkg.0"))
-    is_running = True
-    while is_running:
-        time.sleep(1)
-        try:
-            is_running = download_project_is_running(job)
-        except Exception:
-            download_project_cancel(job)
-            break
+    with pytest.raises(IsADirectoryError):
+        while True:
+            assert download_project_is_running(job)
 
-    if not is_running:
-        try:
-            download_project_finalize(job)
-        except Exception:
-            pass
+    download_project_cancel(job)  # to clean up things
 
     assert job.failure_log_file is not None
     with open(job.failure_log_file, "r", encoding="utf-8") as f:

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -2245,6 +2245,9 @@ def test_download_failure(mc):
         download_project_finalize(job)
 
     assert job.failure_log_file is not None
+    with open(job.failure_log_file, "r", encoding="utf-8") as f:
+        content = f.read()
+        assert "Traceback" in content
 
     # active waiting
     remove_folders([download_dir])
@@ -2266,3 +2269,6 @@ def test_download_failure(mc):
             pass
 
     assert job.failure_log_file is not None
+    with open(job.failure_log_file, "r", encoding="utf-8") as f:
+        content = f.read()
+        assert "Traceback" in content


### PR DESCRIPTION
When project download fails for some reason we remove project directory and raise an exception. This exception than catched in the plugin and error message is shown. However, in some cases (namely, when unexpected error occurs) this message is very basic and it is hard to say what is going on.

The support team proposed that we keep log file as it might contain useful information and provide an option in the plugin to send that log to developers. To make this possible in the client we create a copy of the log file in the system temporary directory before cleaning up failed download. The path to the log file is added to the exception as an attribute and can pluign can check for it and act accordingly.

Fixes #155 
Fixes #156