### PR TITLE
Fix 180

### DIFF
--- a/mergin/cli.py
+++ b/mergin/cli.py
@@ -15,7 +15,6 @@ import platform
 import sys
 import time
 import traceback
-import warnings
 
 from mergin import (
     ClientError,
@@ -568,8 +567,9 @@ def clone(ctx, source_project_path, cloned_project_name, cloned_project_namespac
                 "The `cloned_project_name` should be full name (<namespace>/<name>).",
                 fg="yellow",
             )
-        warnings.filterwarnings("ignore")
-        mc.clone_project(source_project_path, cloned_project_name, cloned_project_namespace)
+        if cloned_project_namespace and "/" not in cloned_project_name:
+            cloned_project_name = f"{cloned_project_namespace}/{cloned_project_name}"
+        mc.clone_project(source_project_path, cloned_project_name)
         click.echo("Done")
     except ClientError as e:
         click.secho("Error: " + str(e), fg="red")

--- a/mergin/cli.py
+++ b/mergin/cli.py
@@ -559,7 +559,7 @@ def clone(ctx, source_project_path, cloned_project_name, cloned_project_namespac
         if cloned_project_namespace:
             click.secho(
                 "The usage of `cloned_project_namespace` parameter in `mergin clone` is deprecated."
-                "Speficy `cloned_project_name` as full name (<namespace>/<name>)) instead.",
+                "Specify `cloned_project_name` as full name (<namespace>/<name>) instead.",
                 fg="yellow",
             )
         if cloned_project_namespace is None and "/" not in cloned_project_name:

--- a/mergin/cli.py
+++ b/mergin/cli.py
@@ -15,6 +15,7 @@ import platform
 import sys
 import time
 import traceback
+import warnings
 
 from mergin import (
     ClientError,
@@ -555,6 +556,15 @@ def clone(ctx, source_project_path, cloned_project_name, cloned_project_namespac
     if mc is None:
         return
     try:
+        if cloned_project_namespace:
+            click.secho("The usage of `cloned_project_namespace` parameter in `mergin clone` is deprecated."
+                        "Speficy `cloned_project_name` as full name (<namespace>/<name>)) instead.",
+                        fg="yellow")
+        if cloned_project_namespace is None and "/" not in cloned_project_name:
+            click.secho("The use of only project name as `cloned_project_name` in `clone_project()` is deprecated."
+                        "The `cloned_project_name` should be full name (<namespace>/<name>).",
+                        fg="yellow")
+        warnings.filterwarnings("ignore")
         mc.clone_project(source_project_path, cloned_project_name, cloned_project_namespace)
         click.echo("Done")
     except ClientError as e:

--- a/mergin/cli.py
+++ b/mergin/cli.py
@@ -557,13 +557,17 @@ def clone(ctx, source_project_path, cloned_project_name, cloned_project_namespac
         return
     try:
         if cloned_project_namespace:
-            click.secho("The usage of `cloned_project_namespace` parameter in `mergin clone` is deprecated."
-                        "Speficy `cloned_project_name` as full name (<namespace>/<name>)) instead.",
-                        fg="yellow")
+            click.secho(
+                "The usage of `cloned_project_namespace` parameter in `mergin clone` is deprecated."
+                "Speficy `cloned_project_name` as full name (<namespace>/<name>)) instead.",
+                fg="yellow",
+            )
         if cloned_project_namespace is None and "/" not in cloned_project_name:
-            click.secho("The use of only project name as `cloned_project_name` in `clone_project()` is deprecated."
-                        "The `cloned_project_name` should be full name (<namespace>/<name>).",
-                        fg="yellow")
+            click.secho(
+                "The use of only project name as `cloned_project_name` in `clone_project()` is deprecated."
+                "The `cloned_project_name` should be full name (<namespace>/<name>).",
+                fg="yellow",
+            )
         warnings.filterwarnings("ignore")
         mc.clone_project(source_project_path, cloned_project_name, cloned_project_namespace)
         click.echo("Done")

--- a/mergin/cli.py
+++ b/mergin/cli.py
@@ -211,13 +211,14 @@ def create(ctx, project, public, from_dir):
     else:
         # namespace not specified, use current user namespace
         namespace = mc.username()
+    project_full_name = f"{namespace}/{project}"
     try:
         if from_dir is None:
-            mc.create_project(project, is_public=public, namespace=namespace)
-            click.echo("Created project " + project)
+            mc.create_project(project_full_name, is_public=public)
+            click.echo("Created project " + project_full_name)
         else:
-            mc.create_project_and_push(project, from_dir, is_public=public, namespace=namespace)
-            click.echo("Created project " + project + " and pushed content from directory " + from_dir)
+            mc.create_project_and_push(project_full_name, from_dir, is_public=public)
+            click.echo("Created project " + project_full_name + " and pushed content from directory " + from_dir)
     except ClientError as e:
         click.secho("Error: " + str(e), fg="red")
         return

--- a/mergin/cli.py
+++ b/mergin/cli.py
@@ -200,25 +200,13 @@ def create(ctx, project, public, from_dir):
     mc = ctx.obj["client"]
     if mc is None:
         return
-    if "/" in project:
-        try:
-            namespace, project = project.split("/")
-            assert namespace, "No namespace given"
-            assert project, "No project name given"
-        except (ValueError, AssertionError) as e:
-            click.secho(f"Incorrect namespace/project format: {e}", fg="red")
-            return
-    else:
-        # namespace not specified, use current user namespace
-        namespace = mc.username()
-    project_full_name = f"{namespace}/{project}"
     try:
         if from_dir is None:
-            mc.create_project(project_full_name, is_public=public)
-            click.echo("Created project " + project_full_name)
+            mc.create_project(project, is_public=public)
+            click.echo("Created project " + project)
         else:
-            mc.create_project_and_push(project_full_name, from_dir, is_public=public)
-            click.echo("Created project " + project_full_name + " and pushed content from directory " + from_dir)
+            mc.create_project_and_push(project, from_dir, is_public=public)
+            click.echo("Created project " + project + " and pushed content from directory " + from_dir)
     except ClientError as e:
         click.secho("Error: " + str(e), fg="red")
         return

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -851,7 +851,7 @@ class MerginClient:
         if cloned_project_namespace and "/" not in cloned_project_name:
             warnings.warn(
                 "The usage of `cloned_project_namespace` parameter in `clone_project()` is deprecated."
-                "Speficy `cloned_project_name` as full name (<namespace>/<name>)) instead.",
+                "Specify `cloned_project_name` as full name (<namespace>/<name>) instead.",
                 category=DeprecationWarning,
             )
 

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -450,7 +450,7 @@ class MerginClient:
         if namespace and "/" not in project_name:
             warnings.warn(
                 "The usage of `namespace` parameter in `create_project()` is deprecated."
-                "Specify `project_name` as full name (<namespace>/<name>)) instead.",
+                "Specify `project_name` as full name (<namespace>/<name>) instead.",
                 category=DeprecationWarning,
             )
 

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -448,22 +448,28 @@ class MerginClient:
             raise Exception("Authentication required")
 
         if namespace and "/" not in project_name:
-            warnings.warn("The usage of `namespace` parameter in `create_project()` is deprecated."
-                          "Specify `project_name` as full name (<namespace>/<name>)) instead.",
-                          category=DeprecationWarning)
+            warnings.warn(
+                "The usage of `namespace` parameter in `create_project()` is deprecated."
+                "Specify `project_name` as full name (<namespace>/<name>)) instead.",
+                category=DeprecationWarning,
+            )
 
         if "/" in project_name:
             if namespace:
-                warnings.warn("Parameter `namespace` specified with full project name (<namespace>/<name>)."
-                              "The parameter will be ignored.")
+                warnings.warn(
+                    "Parameter `namespace` specified with full project name (<namespace>/<name>)."
+                    "The parameter will be ignored."
+                )
 
             splitted = project_name.split("/")
             project_name = splitted[1]
             namespace = splitted[0]
         elif namespace is None:
-            warnings.warn("The use of only project name in `create_project()` is deprecated."
-                          "The `project_name` should be full name (<namespace>/<name>).",
-                          category=DeprecationWarning)
+            warnings.warn(
+                "The use of only project name in `create_project()` is deprecated."
+                "The `project_name` should be full name (<namespace>/<name>).",
+                category=DeprecationWarning,
+            )
 
         params = {"name": project_name, "public": is_public}
         if namespace is None:
@@ -843,22 +849,28 @@ class MerginClient:
         """
 
         if cloned_project_namespace and "/" not in cloned_project_name:
-            warnings.warn("The usage of `cloned_project_namespace` parameter in `clone_project()` is deprecated."
-                          "Speficy `cloned_project_name` as full name (<namespace>/<name>)) instead.",
-                          category=DeprecationWarning)
+            warnings.warn(
+                "The usage of `cloned_project_namespace` parameter in `clone_project()` is deprecated."
+                "Speficy `cloned_project_name` as full name (<namespace>/<name>)) instead.",
+                category=DeprecationWarning,
+            )
 
         if "/" in cloned_project_name:
             if cloned_project_namespace:
-                warnings.warn("Parameter `cloned_project_namespace` specified with full cloned project name (<namespace>/<name>)."
-                              "The parameter will be ignored.")
+                warnings.warn(
+                    "Parameter `cloned_project_namespace` specified with full cloned project name (<namespace>/<name>)."
+                    "The parameter will be ignored."
+                )
 
             splitted = cloned_project_name.split("/")
             cloned_project_name = splitted[1]
             cloned_project_namespace = splitted[0]
         elif cloned_project_namespace is None:
-            warnings.warn("The use of only project name as `cloned_project_name` in `clone_project()` is deprecated."
-                          "The `cloned_project_name` should be full name (<namespace>/<name>).",
-                          category=DeprecationWarning)
+            warnings.warn(
+                "The use of only project name as `cloned_project_name` in `clone_project()` is deprecated."
+                "The `cloned_project_name` should be full name (<namespace>/<name>).",
+                category=DeprecationWarning,
+            )
 
         path = f"/v1/project/clone/{source_project_path}"
         url = urllib.parse.urljoin(self.url, urllib.parse.quote(path))

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -461,9 +461,8 @@ class MerginClient:
                     "The parameter will be ignored."
                 )
 
-            splitted = project_name.split("/")
-            project_name = splitted[1]
-            namespace = splitted[0]
+            namespace, project_name = project_name.split("/")
+
         elif namespace is None:
             warnings.warn(
                 "The use of only project name in `create_project()` is deprecated."
@@ -862,9 +861,8 @@ class MerginClient:
                     "The parameter will be ignored."
                 )
 
-            splitted = cloned_project_name.split("/")
-            cloned_project_name = splitted[1]
-            cloned_project_namespace = splitted[0]
+            cloned_project_namespace, cloned_project_name = cloned_project_name.split("/")
+
         elif cloned_project_namespace is None:
             warnings.warn(
                 "The use of only project name as `cloned_project_name` in `clone_project()` is deprecated."

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -161,7 +161,7 @@ def test_create_remote_project_from_local(mc):
     shutil.copytree(TEST_DATA_DIR, project_dir)
 
     # create remote project
-    mc.create_project_and_push(test_project, directory=project_dir)
+    mc.create_project_and_push(project, directory=project_dir)
 
     # verify we have correct metadata
     source_mp = MerginProject(project_dir)
@@ -212,7 +212,7 @@ def test_push_pull_changes(mc):
     cleanup(mc, project, [project_dir, project_dir_2])
     # create remote project
     shutil.copytree(TEST_DATA_DIR, project_dir)
-    mc.create_project_and_push(test_project, project_dir)
+    mc.create_project_and_push(project, project_dir)
 
     # make sure we have v1 also in concurrent project dir
     mc.download_project(project, project_dir_2)
@@ -309,7 +309,7 @@ def test_cancel_push(mc):
     cleanup(mc, project, [project_dir, project_dir_2])
     # create remote project
     shutil.copytree(TEST_DATA_DIR, project_dir)
-    mc.create_project_and_push(test_project, project_dir)
+    mc.create_project_and_push(project, project_dir)
 
     # modify the project (add, update)
     f_added = "new.txt"
@@ -351,7 +351,7 @@ def test_ignore_files(mc):
     # create remote project
     shutil.copytree(TEST_DATA_DIR, project_dir)
     shutil.copy(os.path.join(project_dir, "test.qgs"), os.path.join(project_dir, "test.qgs~"))
-    mc.create_project_and_push(test_project, project_dir)
+    mc.create_project_and_push(project, project_dir)
     project_info = mc.project_info(project)
     assert not next((f for f in project_info["files"] if f["path"] == "test.qgs~"), None)
 
@@ -371,7 +371,7 @@ def test_sync_diff(mc):
     cleanup(mc, project, [project_dir, project_dir_2, project_dir_3])
     # create remote project
     shutil.copytree(TEST_DATA_DIR, project_dir)
-    mc.create_project_and_push(test_project, project_dir)
+    mc.create_project_and_push(project, project_dir)
 
     # make sure we have v1 also in concurrent project dirs
     mc.download_project(project, project_dir_2)
@@ -438,7 +438,7 @@ def test_list_of_push_changes(mc):
 
     cleanup(mc, project, [project_dir])
     shutil.copytree(TEST_DATA_DIR, project_dir)
-    mc.create_project_and_push(test_project, project_dir)
+    mc.create_project_and_push(project, project_dir)
 
     f_updated = "base.gpkg"
     mp = MerginProject(project_dir)
@@ -457,7 +457,7 @@ def test_token_renewal(mc):
 
     cleanup(mc, project, [project_dir])
     shutil.copytree(TEST_DATA_DIR, project_dir)
-    mc.create_project_and_push(test_project, project_dir)
+    mc.create_project_and_push(project, project_dir)
 
     mc._auth_session["expire"] = datetime.now().replace(tzinfo=pytz.utc) - timedelta(days=1)
     pull_changes, push_changes, _ = mc.project_status(project_dir)
@@ -473,7 +473,7 @@ def test_force_gpkg_update(mc):
     cleanup(mc, project, [project_dir])
     # create remote project
     shutil.copytree(TEST_DATA_DIR, project_dir)
-    mc.create_project_and_push(test_project, project_dir)
+    mc.create_project_and_push(project, project_dir)
 
     # test push changes with force gpkg file upload:
     mp = MerginProject(project_dir)
@@ -539,7 +539,7 @@ def test_missing_basefile_pull(mc):
     cleanup(mc, project, [project_dir, project_dir_2])
     # create remote project
     shutil.copytree(test_data_dir, project_dir)
-    mc.create_project_and_push(test_project, project_dir)
+    mc.create_project_and_push(project, project_dir)
 
     # update our gpkg in a different directory
     mc.download_project(project, project_dir_2)
@@ -570,7 +570,7 @@ def test_empty_file_in_subdir(mc):
     cleanup(mc, project, [project_dir, project_dir_2])
     # create remote project
     shutil.copytree(test_data_dir, project_dir)
-    mc.create_project_and_push(test_project, project_dir)
+    mc.create_project_and_push(project, project_dir)
 
     # try to check out the project
     mc.download_project(project, project_dir_2)
@@ -823,7 +823,7 @@ def test_download_versions(mc):
     cleanup(mc, project, [project_dir, project_dir_v1, project_dir_v2, project_dir_v3])
     # create remote project
     shutil.copytree(TEST_DATA_DIR, project_dir)
-    mc.create_project_and_push(test_project, project_dir)
+    mc.create_project_and_push(project, project_dir)
 
     # create new version - v2
     f_added = "new.txt"
@@ -892,7 +892,7 @@ def test_missing_local_file_pull(mc):
     cleanup(mc, project, [project_dir, project_dir_2])
     # create remote project
     shutil.copytree(test_data_dir, project_dir)
-    mc.create_project_and_push(test_project, project_dir)
+    mc.create_project_and_push(project, project_dir)
 
     # remove a file in a different directory
     mc.download_project(project, project_dir_2)
@@ -935,7 +935,7 @@ def create_versioned_project(mc, project_name, project_dir, updated_file, remove
 
     # create remote project
     shutil.copytree(TEST_DATA_DIR, project_dir)
-    mc.create_project_and_push(project_name, project_dir)
+    mc.create_project_and_push(project, project_dir)
 
     mp = MerginProject(project_dir)
 
@@ -1083,7 +1083,7 @@ def test_modify_project_permissions(mc):
     shutil.copytree(TEST_DATA_DIR, project_dir)
 
     # create remote project
-    mc.create_project_and_push(test_project, directory=project_dir)
+    mc.create_project_and_push(project, directory=project_dir)
 
     # check basic metadata about created project
     project_info = mc.project_info(project)
@@ -1219,7 +1219,7 @@ def test_push_gpkg_schema_change(mc):
     os.makedirs(project_dir)
     shutil.copy(os.path.join(TEST_DATA_DIR, "base.gpkg"), test_gpkg)
     # shutil.copytree(TEST_DATA_DIR, project_dir)
-    mc.create_project_and_push(test_project, project_dir)
+    mc.create_project_and_push(project, project_dir)
 
     mp = MerginProject(project_dir)
 
@@ -1298,7 +1298,7 @@ def test_rebase_local_schema_change(mc, extra_connection):
     os.makedirs(project_dir)
     shutil.copy(os.path.join(TEST_DATA_DIR, "base.gpkg"), test_gpkg)
     _use_wal(test_gpkg)  # make sure we use WAL, that's the more common and more difficult scenario
-    mc.create_project_and_push(test_project, project_dir)
+    mc.create_project_and_push(project, project_dir)
 
     if extra_connection:
         # open a connection and keep it open (qgis does this with a pool of connections too)
@@ -1364,7 +1364,7 @@ def test_rebase_remote_schema_change(mc, extra_connection):
     os.makedirs(project_dir)
     shutil.copy(os.path.join(TEST_DATA_DIR, "base.gpkg"), test_gpkg)
     _use_wal(test_gpkg)  # make sure we use WAL, that's the more common and more difficult scenario
-    mc.create_project_and_push(test_project, project_dir)
+    mc.create_project_and_push(project, project_dir)
 
     # Download project to the concurrent dir + change DB schema + push a new version
     mc.download_project(project, project_dir_2)
@@ -1429,7 +1429,7 @@ def test_rebase_success(mc, extra_connection):
     os.makedirs(project_dir)
     shutil.copy(os.path.join(TEST_DATA_DIR, "base.gpkg"), test_gpkg)
     _use_wal(test_gpkg)  # make sure we use WAL, that's the more common and more difficult scenario
-    mc.create_project_and_push(test_project, project_dir)
+    mc.create_project_and_push(project, project_dir)
 
     # Download project to the concurrent dir + add a row + push a new version
     mc.download_project(project, project_dir_2)
@@ -1590,7 +1590,7 @@ def test_unfinished_pull(mc):
     os.makedirs(project_dir)
     shutil.copy(os.path.join(TEST_DATA_DIR, "base.gpkg"), test_gpkg)
     _use_wal(test_gpkg)  # make sure we use WAL, that's the more common and more difficult scenario
-    mc.create_project_and_push(test_project, project_dir)
+    mc.create_project_and_push(project, project_dir)
 
     # Download project to the concurrent dir + change DB schema + push a new version
     mc.download_project(project, project_dir_2)
@@ -1678,7 +1678,7 @@ def test_unfinished_pull_push(mc):
     os.makedirs(project_dir)
     shutil.copy(os.path.join(TEST_DATA_DIR, "base.gpkg"), test_gpkg)
     _use_wal(test_gpkg)  # make sure we use WAL, that's the more common and more difficult scenario
-    mc.create_project_and_push(test_project, project_dir)
+    mc.create_project_and_push(project, project_dir)
 
     # Download project to the concurrent dir + change DB schema + push a new version
     mc.download_project(project, project_dir_2)
@@ -1882,7 +1882,7 @@ def test_report_failure(mc):
 
     os.makedirs(project_dir)
     shutil.copy(os.path.join(TEST_DATA_DIR, "base.gpkg"), test_gpkg)
-    mc.create_project_and_push(test_project, project_dir)
+    mc.create_project_and_push(project, project_dir)
 
     shutil.copy(os.path.join(TEST_DATA_DIR, "inserted_1_A.gpkg"), test_gpkg)
     mc.push_project(project_dir)
@@ -1919,7 +1919,7 @@ def test_changesets_download(mc):
 
     os.makedirs(project_dir, exist_ok=True)
     shutil.copy(os.path.join(TEST_DATA_DIR, "base.gpkg"), file_path)
-    mc.create_project_and_push(test_project, project_dir)
+    mc.create_project_and_push(project, project_dir)
 
     shutil.copy(os.path.join(TEST_DATA_DIR, "inserted_1_A.gpkg"), file_path)
     mc.push_project(project_dir)
@@ -1963,7 +1963,7 @@ def test_version_info(mc):
 
     os.makedirs(project_dir, exist_ok=True)
     shutil.copy(os.path.join(TEST_DATA_DIR, "base.gpkg"), file_path)
-    mc.create_project_and_push(test_project, project_dir)
+    mc.create_project_and_push(project, project_dir)
 
     shutil.copy(os.path.join(TEST_DATA_DIR, "inserted_1_A.gpkg"), file_path)
     mc.push_project(project_dir)
@@ -1990,7 +1990,7 @@ def test_clean_diff_files(mc):
     cleanup(mc, project, [project_dir, project_dir_2])
     # create remote project
     shutil.copytree(TEST_DATA_DIR, project_dir)
-    mc.create_project_and_push(test_project, project_dir)
+    mc.create_project_and_push(project, project_dir)
 
     # test push changes with diffs:
     mp = MerginProject(project_dir)

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -606,14 +606,14 @@ def test_clone_project(mc: MerginClient):
     cloned_project_dir = os.path.join(TMP_DIR, cloned_project_name)
     cleanup(mc, API_USER + "/" + cloned_project_name, [cloned_project_dir])
 
-    # clone specifying cloned_project_namespace, does clone but raises deprecation warning 
+    # clone specifying cloned_project_namespace, does clone but raises deprecation warning
     with pytest.deprecated_call(match=r"The usage of `cloned_project_namespace` parameter in `clone_project\(\)`"):
         mc.clone_project(test_project_fullname, cloned_project_name, API_USER)
     projects = mc.projects_list(flag="created")
     assert any(p for p in projects if p["name"] == cloned_project_name and p["namespace"] == API_USER)
     cleanup(mc, API_USER + "/" + cloned_project_name, [cloned_project_dir])
 
-    # clone without specifying cloned_project_namespace relies on workspace with user name, does clone but raises deprecation warning 
+    # clone without specifying cloned_project_namespace relies on workspace with user name, does clone but raises deprecation warning
     with pytest.deprecated_call(match=r"The use of only project name as `cloned_project_name` in `clone_project\(\)`"):
         mc.clone_project(test_project_fullname, cloned_project_name)
     projects = mc.projects_list(flag="created")


### PR DESCRIPTION
Fixes #180

Issue deprecation warnings for `mc.create_project()` and `mc.clone_project(()` if `namespace` parameter is specified. Still supports the old syntax for backwards compatability.

`mergin clone ` will also print statements if `CLONED_PROJECT_NAMESPACE` parameter is used or if `CLONED_PROJECT_NAME` is not a full path that includes workspace name.